### PR TITLE
fix(EditableText): remove 'align' from non-block element toolbar options

### DIFF
--- a/components/ui/EditableText.js
+++ b/components/ui/EditableText.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useSlide } from '@livepreso/content-react';
 import style from './EditableText.module.scss';
 
-const blockLevelFormats = ['format', 'list'];
+const blockLevelFormats = ['format', 'list', 'align'];
 
 export const EditableText = React.memo((props) => {
   const {


### PR DESCRIPTION
When a non-block element (eg. p tag) gets given an align, it seems to stick for the immediate changes, but then reverts when you the saved value is reinstated. I have a feeling this can be fixed in the app, but I am removing it from the content until then.