### PR TITLE
fix(typography) inline elements in h tags inherit `--heading-font` font-family

### DIFF
--- a/css/base.scss
+++ b/css/base.scss
@@ -47,6 +47,23 @@ h6 {
   @extend %base-type;
 
   font-family: var(--heading-font);
+
+  /* sane subset of inlines, as per https://www.w3schools.com/html/html_blocks.asp */
+  a,
+  b,
+  br,
+  em,
+  i,
+  label,
+  small,
+  span,
+  strong,
+  sub,
+  sup,
+  tt,
+  var {
+    font-family: var(--heading-font);
+  }
 }
 
 article {


### PR DESCRIPTION
If you use a `<strong>` tag inside an `<h1>` you shouldn't have to force the font back to `var(--heading-font)`, every time.