### PR TITLE
fix(Toggle): alignment of inactive switch

### DIFF
--- a/components/ui/Toggle/Toggle.module.scss
+++ b/components/ui/Toggle/Toggle.module.scss
@@ -46,6 +46,10 @@
       text-align: center;
 
       .icon {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
         opacity: var(--toggle-inactive-icon-opacity);
         transition: opacity 150ms ease-in-out;
 
@@ -82,10 +86,6 @@
         transform: translate3d(var(--toggle-switch-transform), 0, 0);
 
         .icon {
-          display: flex;
-          flex-direction: column;
-          justify-content: center;
-          align-items: center;
           opacity: var(--toggle-active-icon-opacity);
 
           svg {


### PR DESCRIPTION
Wasn't getting enough classes. A bunch were assigned to "is-active" only.