### PR TITLE
EditableImage (wrapper for companywide-dynamic-image / dynamic-image editables)

### DIFF
--- a/components/ui/EditableImage/EditableImage.js
+++ b/components/ui/EditableImage/EditableImage.js
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { useModes, useSlide } from '@livepreso/content-react';
+
+import style from './EditableImage.module.scss';
+
+export const EditableImage = React.memo((props) => {
+  const {
+    id,
+    prepId,
+    isPrep,
+    isCompany,
+    isGlobal,
+    isReadOnly,
+    className,
+    stopPropagation,
+    maxSize,
+    dimensions,
+  } = props;
+  const { slideKey } = useSlide();
+  const { isPresomanager } = useModes();
+  const opts = {};
+
+  if (isPrep && isGlobal) {
+    throw new Error('EditableImage - prep editable values cannot be global');
+  }
+
+  if (isPrep) {
+    opts['data-dynamic-image'] = `${slideKey}-${prepId || id}`;
+  }
+
+  // TODO: Might need some attention for user templates (check with Hugh)
+  if (isCompany) {
+    opts['data-companywide-dynamic-image'] = isGlobal
+      ? id
+      : `${slideKey?.replace('template-', '')}-${id}`;
+  }
+
+  if (isReadOnly) {
+    opts['data-readonly'] = true;
+  }
+  if (maxSize) {
+    opts['data-save-max-width'] = maxSize.width;
+    opts['data-save-max-height'] = maxSize.height;
+  }
+
+  if (dimensions) {
+    opts['data-image-dimensions'] = dimensions;
+  }
+
+  const testid = isPresomanager ? id : prepId || id;
+
+  return (
+    <div
+      data-testid={testid}
+      data-img
+      {...opts}
+      className={classNames(style.image, className)}
+      onClick={stopPropagation ? (e) => e.stopPropagation() : () => {}}
+    />
+  );
+});
+
+EditableImage.propTypes = {
+  id: PropTypes.string.isRequired,
+  prepId: PropTypes.string,
+  isPrep: PropTypes.bool,
+  isCompany: PropTypes.bool,
+  /**
+   * CWE field with shared content across multiple slides
+   */
+  isGlobal: PropTypes.bool,
+  isReadOnly: PropTypes.bool,
+  className: PropTypes.string,
+  dimensions: PropTypes.string,
+  stopPropagation: PropTypes.bool,
+  maxSize: PropTypes.exact({
+    width: PropTypes.number,
+    height: PropTypes.number,
+  }),
+};
+
+EditableImage.defaultProps = {
+  prepId: null,
+  isPrep: false,
+  isCompany: false,
+  isGlobal: false,
+  isReadOnly: false,
+  className: '',
+  dimensions: '',
+  stopPropagation: false,
+  maxSize: null,
+};

--- a/components/ui/EditableImage/EditableImage.module.scss
+++ b/components/ui/EditableImage/EditableImage.module.scss
@@ -1,0 +1,64 @@
+:root {
+  --editable-image-background-color: #ddd;
+  --editable-image-color: #888;
+}
+
+$placeholder-size: 9rem;
+
+.image {
+  height: 100%;
+  width: 100%;
+
+  // always tinted when empty, even without rec. dimensions set
+  &:global(.sp-companywide-empty) {
+    background-color: var(--editable-image-background-color);
+  }
+
+  &:global([data-dynamic-image]),
+  &:global([data-companywide-dynamic-image]) {
+    &::after {
+      content: none;
+    }
+
+    &:global(.sp-companywide-empty) {
+      :global(.edit-mode:not(.present)) &,
+      :global(.preview) &,
+      :global(.screenshot-thumbnail) & {
+        position: relative;
+
+        &:global([data-image-dimensions]) {
+          &::after {
+            content: 'Recommended image dimensions: \A'
+              attr(data-image-dimensions);
+            display: flex;
+            align-items: flex-end;
+            position: absolute;
+            top: calc(50% - calc($placeholder-size/2));
+            left: calc(50% - calc($placeholder-size/2));
+            height: $placeholder-size;
+            width: $placeholder-size;
+            text-align: center;
+            font-size: 0.8rem;
+            line-height: 1rem;
+            color: var(--editable-image-color);
+            background-image: url('./EditableImageGraphic.svg');
+            background-repeat: no-repeat;
+            background-position: center top;
+            background-size: $placeholder-size/1.5;
+            pointer-events: none;
+          }
+        }
+      }
+    }
+  }
+
+  &[data-readonly] {
+    &::before {
+      display: none;
+    }
+
+    .dropzone-element {
+      display: none;
+    }
+  }
+}

--- a/components/ui/EditableImage/EditableImageGraphic.svg
+++ b/components/ui/EditableImage/EditableImageGraphic.svg
@@ -1,0 +1,27 @@
+<!-- Generator: Adobe Illustrator 24.3.0, SVG Export Plug-In  -->
+<svg
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    x="0px"
+    y="0px"
+    width="52.9px"
+    height="48.9px"
+    viewBox="0 0 52.9 48.9"
+    style="overflow:visible;enable-background:new 0 0 52.9 48.9;"
+    xml:space="preserve"
+>
+<style type="text/css">
+	.st0{fill:none;stroke:#888;stroke-width:3.6;stroke-miterlimit:10;}
+</style>
+<defs>
+</defs>
+<g>
+	<g>
+		<g>
+			<circle class="st0" cx="16" cy="32.9" r="14.2" />
+		</g>
+		<polygon class="st0" points="32.9,3.6 16,32.9 49.8,32.9 		" />
+	</g>
+</g>
+</svg>

--- a/components/ui/EditableImage/index.js
+++ b/components/ui/EditableImage/index.js
@@ -1,0 +1,1 @@
+export { EditableImage } from './EditableImage';

--- a/components/ui/index.js
+++ b/components/ui/index.js
@@ -11,6 +11,7 @@ export { Tabs } from './Tabs';
 // subdirs
 export { Button, ExternalLink } from './Button';
 export { Checkbox } from './Checkbox';
+export { EditableImage } from './EditableImage';
 export * from './Dropdown';
 export * from './Table';
 export { Toggle } from './Toggle';

--- a/css/normalize/_import.scss
+++ b/css/normalize/_import.scss
@@ -3,6 +3,4 @@
 
 @import 'normalize';
 
-#slideshow {
-  @include normalize;
-}
+@include normalize;


### PR DESCRIPTION
Ported from JC with a few consolidations and style cleanups. 

Also has small fix for `normalize` styles - removed `#slideshow` prefix as webpack wraps everything in `#presenter` now to allow for overlay / portal unscaled content.