### PR TITLE
Fix/accordion icon position

### DIFF
--- a/components/ui/Table/TableRow.js
+++ b/components/ui/Table/TableRow.js
@@ -14,6 +14,7 @@ export const TableRow = React.forwardRef(
       active: _active,
       parentKeys: _parentKeys,
       isOver: _isOver,
+      accordionButtonAlign: _accordionButtonAlign,
       ...props
     },
     forwardedRef,

--- a/components/ui/Table/rows/AccordionRow.js
+++ b/components/ui/Table/rows/AccordionRow.js
@@ -91,6 +91,7 @@ function ManagedAccordionRow({ uid, ...props }) {
  * @param {RowShape[]} [props.rows=[]] - Nested row configurations.
  * @param {Function} [props.component=null] - Custom component to render.
  * @param {string} [props.type=null] - The specific ROW_TYPES value.
+ * @param {String} [props.accordionButtonAlign='middle'] - Aligns the accordion button ('top', 'middle').
  * @param {React.ReactNode} [props.children=null] - Child elements.
  * @param {string} [props.className=''] - CSS class name.
  */
@@ -103,6 +104,7 @@ function AccordionRowBase({
   children = null,
   className = '',
   isOpen = false,
+  accordionButtonAlign = 'middle',
   ...rowProps
 }) {
   const RowComponent =
@@ -117,9 +119,14 @@ function AccordionRowBase({
         data-accordion-header={uid}
         data-accordion-parent={parentKeys.join(' ')}
         {...rowProps}
-        className={classNames(className, style.accordionRow, {
-          [style.isOpen]: isOpen,
-        })}
+        className={classNames(
+          className,
+          style.accordionRow,
+          [style[`accordion-button-${accordionButtonAlign}`]],
+          {
+            [style.isOpen]: isOpen,
+          },
+        )}
       >
         {children}
       </RowComponent>

--- a/components/ui/Table/rows/AccordionRow.module.scss
+++ b/components/ui/Table/rows/AccordionRow.module.scss
@@ -28,4 +28,10 @@
       }
     }
   }
+
+  &.accordion-button-top {
+    td:first-child::before {
+      top: calc(var(--table-cell-padding-v) + 0.65em);
+    }
+  }
 }

--- a/components/ui/Table/rows/AccordionRow.module.scss
+++ b/components/ui/Table/rows/AccordionRow.module.scss
@@ -10,8 +10,9 @@
     &::before {
       content: '';
       position: absolute;
-      top: calc(50% - 0.2em);
+      top: 50%;
       left: var(--table-cell-padding-h);
+      margin-top: -0.2em;
       border: var(--table-accordion-width) solid transparent;
       border-top-color: var(--table-cell-text-color);
       width: 0;
@@ -22,7 +23,7 @@
   &.is-open {
     td:first-child {
       &::before {
-        top: calc(50% - 0.8em);
+        margin-top: -0.8em;
         transform: scaleY(-1);
       }
     }


### PR DESCRIPTION
Allows devs to specify whether they want a middle (default) or top aligned accordion button. Also tweaked styling so it's easier to manually override when needed by the content (but can hopefully be avoided now).